### PR TITLE
add Dockerfile and readme for headless SITL in a docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The C++ wrapper uses JNI to communicate with the C++ library.
 
 The Android app can be tested against the software simulation.
 
-The SITL can be used on Linux or Mac. The use in a virtualization environment such as VirtualBox is possible but generally not recommended for performance reasons.
+The SITL can be used on Linux or Mac. The use in a virtualization environment such as VirtualBox is possible but generally not recommended for performance reasons. A headless instance can be run inside a Docker container, as explained [here](sitl).
 
 ### Installing Gazebo7
 

--- a/sitl/Dockerfile
+++ b/sitl/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:16.04
+
+RUN apt-get update
+RUN apt-get install -y apt-utils
+RUN apt-get install -y wget
+RUN apt-get install -y unzip
+RUN apt-get install -y lsb-release
+
+RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
+RUN wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+
+RUN apt-get update
+RUN apt-get install -y gazebo7 libgazebo7-dev
+
+RUN wget https://s3.eu-central-1.amazonaws.com/08f61bbd-8958-433e-8e83-5d79160fa0be/sitl/latest/Yuneec-SITL-Simulation-Linux.zip -P /root/
+RUN unzip /root/Yuneec-SITL-Simulation-Linux.zip -d /root/
+RUN mkdir /root/posix-configs/SITL/init/ekf2
+RUN cp /root/posix-configs/SITL/init/default/typhoon_h480 /root/posix-configs/SITL/init/ekf2/typhoon_h480
+
+EXPOSE 14540
+EXPOSE 14550
+
+WORKDIR /root
+CMD HEADLESS=1 /root/typhoon_sitl.bash

--- a/sitl/README.md
+++ b/sitl/README.md
@@ -1,0 +1,17 @@
+# Running SITL in Docker
+## Description
+This is an example of running SITL headless in a Docker container.
+
+## Building the docker image
+From this directory, run:
+
+    $ docker build -t yuneec-sitl .
+
+An image called `yuneec-sitl` should be created. Note that the latest version of the SITL simulator is downloaded at that point.
+
+## Running a SITL container
+Run the following command:
+
+    $ docker run -it yuneec-sitl
+
+More details on how to use the SITL simulation can be found [here](https://github.com/YUNEEC/Yuneec-SDK-iOS-Example-prerelease#run-the-simulation).


### PR DESCRIPTION
As I am running SITL from a docker instance, I thought it could be worth sharing the Dockerfile.

Let me know if you think I should make a similar one on the iOS example.