### PR TITLE
README: opencv is now in brew core

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ brew install gazebo7
 ```
 OpenCV is required to run the simulation.
 ```
-brew tap homebrew/science
 brew install opencv
 ```
 


### PR DESCRIPTION
This fixes the Gazebo install instructions for Mac.