### PR TITLE
README: switch from s3 to cloudfront for SITL zips

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Instructions taken from [gazebosim.org](http://gazebosim.org/tutorials?tut=insta
 
 ### Get the SITL simulation
 
-Download the zip containing the SITL simulation for [macOS 10.12](https://s3.eu-central-1.amazonaws.com/08f61bbd-8958-433e-8e83-5d79160fa0be/sitl/macOS/latest/Yuneec-SITL-Simulation-macOS.zip) or [Ubuntu 16.04](https://s3.eu-central-1.amazonaws.com/08f61bbd-8958-433e-8e83-5d79160fa0be/sitl/Linux/latest/Yuneec-SITL-Simulation-Linux.zip).
+Download the zip containing the SITL simulation for [macOS 10.12](https://d3qzlqwby7grio.cloudfront.net/H520/sitl/macOS/Yuneec-SITL-Simulation-macOS.zip) or [Ubuntu 16.04](https://d3qzlqwby7grio.cloudfront.net/H520/sitl/Linux/Yuneec-SITL-Simulation-Linux.zip).
 
 ### Run the simulation
 


### PR DESCRIPTION
This allows for faster downloads for everyone not in central Europe.