### PR TITLE
Update Yuneec-SDK-Android, gradle and SDK version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
   - "$HOME/.gradle/wrapper/"
 env:
   global:
-  - ANDROID_API=25
+  - ANDROID_API=26
   - ANDROID_BUILD_TOOLS=26.0.2
   - ADB_INSTALL_TIMEOUT=5
 android:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,5 +31,5 @@ dependencies {
     })
     compile 'com.android.support:appcompat-v7:25.3.1'
     testCompile 'junit:junit:4.12'
-    compile 'com.github.YUNEEC:Yuneec-SDK-Android:v0.7.7'
+    compile 'com.github.YUNEEC:Yuneec-SDK-Android:v0.8.0-1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
 
     defaultConfig {
         applicationId "com.yuneec.yuneecandroidexample"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -29,7 +29,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     testCompile 'junit:junit:4.12'
     compile 'com.github.YUNEEC:Yuneec-SDK-Android:v0.8.0-1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ allprojects {
         maven {
             url 'https://jitpack.io'
         }
+        google()
     }
 }
 task clean(type: Delete) {


### PR DESCRIPTION
This updates the Yuneec-SDK-Android to `v0.8.0-1`.

It is now deployed differently internally, and the tag format has an additional `-x` version number for the Android iteration on top of the C++ DroneCore version.