### PR TITLE
Update DroneCore and fix crash on exit

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,6 @@ dependencies {
     })
     compile 'com.android.support:appcompat-v7:26.1.0'
     testCompile 'junit:junit:4.12'
-    compile 'com.github.YUNEEC:Yuneec-SDK-Android:v0.9.0-0'
+    compile 'com.github.YUNEEC:Yuneec-SDK-Android:v0.11.2-0'
     compile 'com.github.YUNEEC:Yuneec-RTSP-Player-Android:v0.1'
 }

--- a/app/src/main/java/com/yuneec/example/component/fragment/ConnectionFragment.java
+++ b/app/src/main/java/com/yuneec/example/component/fragment/ConnectionFragment.java
@@ -66,13 +66,13 @@ public class ConnectionFragment
     public void onStop() {
 
         super.onStop();
+        unRegisterListener();
     }
 
     @Override
     public void onDestroyView() {
 
         super.onDestroyView();
-        unRegisterListener();
     }
 
     @Override

--- a/app/src/main/java/com/yuneec/example/component/fragment/ConnectionFragment.java
+++ b/app/src/main/java/com/yuneec/example/component/fragment/ConnectionFragment.java
@@ -58,7 +58,7 @@ public class ConnectionFragment
     public void onStart() {
 
         super.onStart();
-        registerListener();
+        registerListeners();
 
     }
 
@@ -66,7 +66,7 @@ public class ConnectionFragment
     public void onStop() {
 
         super.onStop();
-        unRegisterListener();
+        unRegisterListeners();
     }
 
     @Override
@@ -87,16 +87,14 @@ public class ConnectionFragment
         super.onResume();
     }
 
-    private void registerListener() {
+    private void registerListeners() {
 
-        CameraListener.registerCameraListener(getActivity());
         TelemetryListener.registerBatteryListener(getActivity());
         TelemetryListener.registerHealthListener(getActivity());
     }
 
-    private void unRegisterListener() {
+    private void unRegisterListeners() {
 
-        CameraListener.unRegisterCameraListener();
         TelemetryListener.unRegisterBatteryListener();
         TelemetryListener.unRegisterHealthListener();
     }

--- a/app/src/main/java/com/yuneec/example/component/fragment/TelemetryFragment.java
+++ b/app/src/main/java/com/yuneec/example/component/fragment/TelemetryFragment.java
@@ -321,9 +321,6 @@ public class TelemetryFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        YCListener listener = new YCListener();
-        Connection.addListener(listener);
-
         ArrayList<TelemetryEntry> list = GetInitialTelemetrylist();
 
         adapter = new ListviewTelemetryAdapter(getActivity(), list);
@@ -381,20 +378,4 @@ public class TelemetryFragment extends Fragment {
         Telemetry.setInAirListener(new InAirListener());
         Telemetry.setRCStatusListener(new RCStatusListener());
     }
-
-    class YCListener implements Connection.Listener {
-
-        @Override
-        public void onDiscoverCallback() {
-            // When a new device has connected, we need to subscribe all listeners again.
-            subscribe();
-        }
-
-        @Override
-        public void onTimeoutCallback() {
-            // Do nothing, leave last values.
-        }
-    }
-
-    ;
 }


### PR DESCRIPTION
Unregister listeners in onStop() callback.

Fixes #42.