### PR TITLE
gradle: update wrapper to v0.11.03-0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,6 @@ dependencies {
     })
     compile 'com.android.support:appcompat-v7:26.1.0'
     testCompile 'junit:junit:4.12'
-    compile 'com.github.YUNEEC:Yuneec-SDK-Android:v0.11.2-0'
+    compile 'com.github.YUNEEC:Yuneec-SDK-Android:v0.11.3-0'
     compile 'com.github.YUNEEC:Yuneec-RTSP-Player-Android:v0.1'
 }


### PR DESCRIPTION
This contains mostly build changes under the hood, and also resolves an ST16 bug where pairing was answered with `UNSUPPORTED_PLATFORM`.