### PR TITLE
MediaDownloadFragment: move downloading flag

### DIFF
--- a/app/src/main/java/com/yuneec/example/component/fragment/MediaDownloadFragment.java
+++ b/app/src/main/java/com/yuneec/example/component/fragment/MediaDownloadFragment.java
@@ -173,12 +173,12 @@ public class MediaDownloadFragment extends Fragment implements
                                         entry.downloaded = true;
                                         adapter.notifyDataSetChanged();
                                     }
+                                    downloadingMedia = false;
                                 } else {
                                     updateToast("Downloaded " + progress + " %");
                                 }
                             }
                         });
-                        downloadingMedia = false;
                     }
 
                 };


### PR DESCRIPTION
We stop downloading only when we receive a result other than in progress
inside the callback.